### PR TITLE
Revamp design with dark theme

### DIFF
--- a/carkspin/FriendsView.swift
+++ b/carkspin/FriendsView.swift
@@ -10,14 +10,10 @@ struct FriendsView: View {
     var body: some View {
         NavigationView {
             ZStack {
-                // Daha modern gradient
                 LinearGradient(
-                    gradient: Gradient(colors: [
-                        Color(red: 0.2, green: 0.6, blue: 1.0),
-                        Color(red: 0.6, green: 0.3, blue: 1.0)
-                    ]),
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
+                    gradient: Gradient(colors: [Color.black, Color.green.opacity(0.7)]),
+                    startPoint: .top,
+                    endPoint: .bottom
                 )
                 .ignoresSafeArea()
                 
@@ -28,16 +24,15 @@ struct FriendsView: View {
                             Button(action: { dismiss() }) {
                                 Image(systemName: "xmark.circle.fill")
                                     .font(.title2)
-                                    .foregroundColor(.white.opacity(0.8))
+                                    .foregroundColor(.yellow.opacity(0.9))
                                     .background(Circle().fill(.ultraThinMaterial))
                             }
                             
                             Spacer()
                             
                             Text("Arkadaş Ara")
-                                .font(.title2)
-                                .fontWeight(.bold)
-                                .foregroundColor(.white)
+                                .font(.system(size: 24, weight: .heavy, design: .rounded))
+                                .foregroundColor(.yellow)
                             
                             Spacer()
                             
@@ -53,9 +48,9 @@ struct FriendsView: View {
                             Image(systemName: "magnifyingglass")
                                 .foregroundColor(.gray)
                                 .font(.system(size: 18))
-                            
+
                             TextField("Kullanıcı adı ara...", text: $searchText)
-                                .font(.body)
+                                .font(.system(size: 16, weight: .medium, design: .rounded))
                                 .foregroundColor(.primary)
                                 .onSubmit {
                                     searchUsers()
@@ -91,26 +86,25 @@ struct FriendsView: View {
                         VStack(spacing: 20) {
                             ProgressView()
                                 .scaleEffect(1.5)
-                                .tint(.white)
+                                .tint(.yellow)
                             Text("Aranıyor...")
-                                .font(.headline)
-                                .foregroundColor(.white.opacity(0.8))
+                                .font(.system(size: 16, weight: .medium, design: .rounded))
+                                .foregroundColor(.yellow.opacity(0.8))
                         }
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                     } else if searchResults.isEmpty && !searchText.isEmpty {
                         VStack(spacing: 20) {
                             Image(systemName: "person.fill.questionmark")
                                 .font(.system(size: 50))
-                                .foregroundColor(.white.opacity(0.6))
+                                .foregroundColor(.green.opacity(0.6))
                             
                             Text("Kullanıcı bulunamadı")
-                                .font(.title3)
-                                .fontWeight(.semibold)
-                                .foregroundColor(.white)
+                                .font(.system(size: 20, weight: .heavy, design: .rounded))
+                                .foregroundColor(.yellow)
                             
                             Text("'\(searchText)' ile eşleşen kullanıcı bulunamadı")
-                                .font(.subheadline)
-                                .foregroundColor(.white.opacity(0.7))
+                                .font(.system(size: 14, weight: .medium, design: .rounded))
+                                .foregroundColor(.yellow.opacity(0.8))
                                 .multilineTextAlignment(.center)
                         }
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -119,17 +113,16 @@ struct FriendsView: View {
                         VStack(spacing: 25) {
                             Image(systemName: "person.2.badge.plus")
                                 .font(.system(size: 60))
-                                .foregroundColor(.white.opacity(0.6))
+                                .foregroundColor(.green.opacity(0.6))
                             
                             VStack(spacing: 10) {
                                 Text("Arkadaş Keşfet")
-                                    .font(.title2)
-                                    .fontWeight(.bold)
-                                    .foregroundColor(.white)
+                                    .font(.system(size: 22, weight: .heavy, design: .rounded))
+                                    .foregroundColor(.yellow)
                                 
                                 Text("Kullanıcı adı ile arkadaşlarını bul\nve birlikte çark çevirin!")
-                                    .font(.body)
-                                    .foregroundColor(.white.opacity(0.8))
+                                    .font(.system(size: 14, weight: .medium, design: .rounded))
+                                    .foregroundColor(.yellow.opacity(0.85))
                                     .multilineTextAlignment(.center)
                                     .lineSpacing(4)
                             }
@@ -188,21 +181,21 @@ struct UserCard: View {
                 ZStack {
                     Circle()
                         .fill(LinearGradient(
-                            gradient: Gradient(colors: [.blue.opacity(0.3), .purple.opacity(0.3)]),
+                            gradient: Gradient(colors: [.green.opacity(0.3), .yellow.opacity(0.3)]),
                             startPoint: .topLeading,
                             endPoint: .bottomTrailing
                         ))
                     
                     Image(systemName: "person.fill")
                         .font(.title2)
-                        .foregroundColor(.white.opacity(0.8))
+                        .foregroundColor(.yellow.opacity(0.8))
                 }
             }
             .frame(width: 60, height: 60)
             .clipShape(Circle())
             .overlay(
                 Circle()
-                    .stroke(.white.opacity(0.3), lineWidth: 2)
+                    .stroke(Color.yellow.opacity(0.3), lineWidth: 2)
             )
             
             // Kullanıcı bilgileri
@@ -239,20 +232,22 @@ struct UserCard: View {
                 HStack(spacing: 8) {
                     Image(systemName: isInviteSent ? "checkmark.circle.fill" : "paperplane.fill")
                         .font(.system(size: 16))
-                    
+
                     Text(isInviteSent ? "Gönderildi" : "Çark İsteği")
-                        .font(.system(size: 14, weight: .semibold))
+                        .font(.system(size: 14, weight: .bold, design: .rounded))
                 }
-                .foregroundColor(isInviteSent ? .white : .white)
+                .foregroundColor(.yellow)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 10)
                 .background(
-                    isInviteSent ? 
-                    LinearGradient(gradient: Gradient(colors: [.green, .green.opacity(0.8)]), startPoint: .leading, endPoint: .trailing) :
-                    LinearGradient(gradient: Gradient(colors: [.blue, .purple]), startPoint: .leading, endPoint: .trailing)
+                    LinearGradient(
+                        colors: isInviteSent ? [Color.green, Color.green.opacity(0.8)] : [Color.green, Color.yellow],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
                 )
                 .clipShape(Capsule())
-                .shadow(color: isInviteSent ? .green.opacity(0.3) : .blue.opacity(0.3), radius: 8, x: 0, y: 4)
+                .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
             }
             .disabled(isInviteSent)
             .scaleEffect(isInviteSent ? 0.95 : 1.0)
@@ -262,7 +257,7 @@ struct UserCard: View {
         .background(.ultraThickMaterial, in: RoundedRectangle(cornerRadius: 20))
         .overlay(
             RoundedRectangle(cornerRadius: 20)
-                .stroke(.white.opacity(0.2), lineWidth: 1)
+                .stroke(Color.yellow.opacity(0.2), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: 5)
     }

--- a/carkspin/LoginView.swift
+++ b/carkspin/LoginView.swift
@@ -7,9 +7,9 @@ struct LoginView: View {
     var body: some View {
         ZStack {
             LinearGradient(
-                gradient: Gradient(colors: [Color.blue.opacity(0.6), Color.purple.opacity(0.8)]),
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
+                gradient: Gradient(colors: [Color.black, Color.green.opacity(0.7)]),
+                startPoint: .top,
+                endPoint: .bottom
             )
             .ignoresSafeArea()
             
@@ -18,17 +18,16 @@ struct LoginView: View {
                 
                 VStack(spacing: 20) {
                     Image(systemName: "sparkles")
-                        .font(.system(size: 80))
-                        .foregroundColor(.white)
-                    
+                        .font(.system(size: 80, weight: .black, design: .rounded))
+                        .foregroundStyle(.yellow)
+
                     Text("ÇarkSpin")
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
-                        .foregroundColor(.white)
-                    
+                        .font(.system(size: 40, weight: .heavy, design: .rounded))
+                        .foregroundColor(.yellow)
+
                     Text("Arkadaşlarınla eğlenceli kararlar verin!")
-                        .font(.title3)
-                        .foregroundColor(.white.opacity(0.8))
+                        .font(.system(size: 18, weight: .medium, design: .rounded))
+                        .foregroundColor(.yellow.opacity(0.9))
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 40)
                 }
@@ -41,17 +40,18 @@ struct LoginView: View {
                     }) {
                         HStack {
                             Image(systemName: "person.circle.fill")
-                                .foregroundColor(.blue)
-                            
+                                .font(.title3)
                             Text("Google ile Giriş Yap")
-                                .fontWeight(.semibold)
+                                .font(.system(size: 16, weight: .bold, design: .rounded))
                         }
+                        .foregroundColor(.yellow)
                         .frame(maxWidth: .infinity)
-                        .frame(height: 50)
-                        .background(Color.white)
-                        .foregroundColor(.primary)
-                        .cornerRadius(25)
-                        .shadow(radius: 10, x: 0, y: 5)
+                        .frame(height: 55)
+                        .background(
+                            LinearGradient(colors: [Color.green, Color.yellow], startPoint: .topLeading, endPoint: .bottomTrailing)
+                        )
+                        .clipShape(Capsule())
+                        .shadow(color: .black.opacity(0.2), radius: 5, x: 0, y: 3)
                     }
                     .disabled(authService.isLoading)
                     .opacity(authService.isLoading ? 0.6 : 1.0)
@@ -59,7 +59,7 @@ struct LoginView: View {
                     if authService.isLoading {
                         ProgressView()
                             .scaleEffect(1.2)
-                            .tint(.white)
+                            .tint(.yellow)
                     }
                     
                     if let errorMessage = authService.errorMessage {

--- a/carkspin/SpinWheelView.swift
+++ b/carkspin/SpinWheelView.swift
@@ -20,9 +20,9 @@ struct SpinWheelView: View {
                 // Premium gradient arka plan
                 RadialGradient(
                     gradient: Gradient(colors: [
-                        Color(red: 0.1, green: 0.1, blue: 0.2),
-                        Color(red: 0.2, green: 0.1, blue: 0.3),
-                        Color(red: 0.1, green: 0.0, blue: 0.2)
+                        Color.black,
+                        Color.green.opacity(0.8),
+                        Color.yellow.opacity(0.3)
                     ]),
                     center: .center,
                     startRadius: 100,
@@ -33,7 +33,7 @@ struct SpinWheelView: View {
                 // Arka plan parçacıkları
                 ForEach(0..<20, id: \.self) { _ in
                     Circle()
-                        .fill(.white.opacity(0.1))
+                        .fill(Color.yellow.opacity(0.1))
                         .frame(width: Double.random(in: 2...6))
                         .position(
                             x: Double.random(in: 0...geometry.size.width),
@@ -51,7 +51,7 @@ struct SpinWheelView: View {
                                 .font(.system(size: 28, weight: .black, design: .rounded))
                                 .foregroundStyle(
                                     LinearGradient(
-                                        colors: [.white, .blue.opacity(0.8)],
+                                        colors: [Color.green, Color.yellow],
                                         startPoint: .topLeading,
                                         endPoint: .bottomTrailing
                                     )
@@ -59,7 +59,7 @@ struct SpinWheelView: View {
                             
                             Text("Şansını dene!")
                                 .font(.caption)
-                                .foregroundColor(.white.opacity(0.7))
+                                .foregroundColor(.yellow.opacity(0.7))
                         }
                         
                         Spacer()
@@ -73,7 +73,7 @@ struct SpinWheelView: View {
                                         Circle()
                                             .stroke(
                                                 LinearGradient(
-                                                    colors: [.blue.opacity(0.5), .purple.opacity(0.5)],
+                                                    colors: [Color.green.opacity(0.5), Color.yellow.opacity(0.5)],
                                                     startPoint: .topLeading,
                                                     endPoint: .bottomTrailing
                                                 ),
@@ -83,7 +83,7 @@ struct SpinWheelView: View {
                                 
                                 Image(systemName: "person.2.fill")
                                     .font(.system(size: 18, weight: .semibold))
-                                    .foregroundColor(.white)
+                                    .foregroundColor(.yellow)
                             }
                         }
                     }
@@ -98,7 +98,7 @@ struct SpinWheelView: View {
                         Circle()
                             .fill(
                                 RadialGradient(
-                                    colors: [.blue.opacity(0.3), .purple.opacity(0.2), .clear],
+                                    colors: [Color.green.opacity(0.3), Color.yellow.opacity(0.2), .clear],
                                     center: .center,
                                     startRadius: 50,
                                     endRadius: 200
@@ -115,14 +115,14 @@ struct SpinWheelView: View {
                             Circle()
                                 .stroke(
                                     LinearGradient(
-                                        colors: [.white.opacity(0.8), .blue.opacity(0.6)],
+                                        colors: [Color.green.opacity(0.8), Color.yellow.opacity(0.6)],
                                         startPoint: .topLeading,
                                         endPoint: .bottomTrailing
                                     ),
                                     lineWidth: 8
                                 )
                                 .frame(width: 310, height: 310)
-                                .shadow(color: .white.opacity(0.3), radius: 5, x: 0, y: 0)
+                                .shadow(color: Color.yellow.opacity(0.3), radius: 5, x: 0, y: 0)
                             
                             // Çark segmentleri
                             ForEach(0..<options.count, id: \.self) { index in
@@ -140,7 +140,7 @@ struct SpinWheelView: View {
                                 Circle()
                                     .fill(
                                         RadialGradient(
-                                            colors: [.white, .gray.opacity(0.3)],
+                                            colors: [Color.yellow, Color.green.opacity(0.3)],
                                             center: .center,
                                             startRadius: 5,
                                             endRadius: 30
@@ -150,7 +150,7 @@ struct SpinWheelView: View {
                                     .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
                                 
                                 Circle()
-                                    .stroke(.white.opacity(0.5), lineWidth: 2)
+                                    .stroke(Color.yellow.opacity(0.5), lineWidth: 2)
                                     .frame(width: 45, height: 45)
                                 
                                 Text("SPIN")
@@ -171,7 +171,7 @@ struct SpinWheelView: View {
                                     Pointer()
                                         .fill(
                                             LinearGradient(
-                                                colors: [.white, .gray.opacity(0.8)],
+                                                colors: [Color.yellow, Color.green.opacity(0.8)],
                                                 startPoint: .top,
                                                 endPoint: .bottom
                                             )
@@ -201,9 +201,9 @@ struct SpinWheelView: View {
                                 RoundedRectangle(cornerRadius: 30)
                                     .fill(
                                         LinearGradient(
-                                            colors: isSpinning ? 
+                                            colors: isSpinning ?
                                                 [.gray.opacity(0.4), .gray.opacity(0.6)] :
-                                                [.orange.opacity(0.8), .red.opacity(0.9)],
+                                                [Color.pink.opacity(0.8), Color.orange.opacity(0.9)],
                                             startPoint: .topLeading,
                                             endPoint: .bottomTrailing
                                         )
@@ -216,9 +216,9 @@ struct SpinWheelView: View {
                                 RoundedRectangle(cornerRadius: 30)
                                     .fill(
                                         LinearGradient(
-                                            colors: isSpinning ? 
+                                            colors: isSpinning ?
                                                 [.gray.opacity(0.6), .gray.opacity(0.8)] :
-                                                [.orange, .red],
+                                                [Color.pink, Color.orange],
                                             startPoint: .topLeading,
                                             endPoint: .bottomTrailing
                                         )
@@ -226,23 +226,23 @@ struct SpinWheelView: View {
                                     .frame(height: 65)
                                     .overlay(
                                         RoundedRectangle(cornerRadius: 30)
-                                            .stroke(.white.opacity(0.3), lineWidth: 1)
+                                            .stroke(Color.yellow.opacity(0.3), lineWidth: 1)
                                     )
                                 
                                 HStack(spacing: 12) {
                                     if isSpinning {
                                         ProgressView()
                                             .scaleEffect(0.9)
-                                            .tint(.white)
+                                            .tint(.yellow)
                                     } else {
                                         Image(systemName: "arrow.triangle.2.circlepath")
                                             .font(.title2)
-                                            .foregroundColor(.white)
+                                            .foregroundColor(.yellow)
                                     }
                                     
                                     Text(isSpinning ? "ÇARK DÖNÜYOR..." : "ÇARKI ÇEVİR!")
                                         .font(.system(size: 18, weight: .black, design: .rounded))
-                                        .foregroundColor(.white)
+                                        .foregroundColor(.yellow)
                                 }
                             }
                         }
@@ -257,14 +257,14 @@ struct SpinWheelView: View {
                                 Text("Arkadaşlarla Oyna")
                                     .font(.system(size: 16, weight: .semibold))
                             }
-                            .foregroundColor(.white)
+                            .foregroundColor(.yellow)
                             .frame(maxWidth: .infinity)
                             .frame(height: 50)
                             .background(.ultraThinMaterial)
                             .clipShape(RoundedRectangle(cornerRadius: 25))
                             .overlay(
                                 RoundedRectangle(cornerRadius: 25)
-                                    .stroke(.white.opacity(0.3), lineWidth: 1)
+                                    .stroke(Color.yellow.opacity(0.3), lineWidth: 1)
                             )
                         }
                     }
@@ -348,7 +348,7 @@ struct ProfessionalWheelSegment: View {
                 .overlay(
                     Circle()
                         .trim(from: startAngle / 360, to: endAngle / 360)
-                        .stroke(.white.opacity(0.3), lineWidth: 2)
+                        .stroke(Color.yellow.opacity(0.3), lineWidth: 2)
                         .frame(width: 300, height: 300)
                 )
             
@@ -357,7 +357,7 @@ struct ProfessionalWheelSegment: View {
                 .trim(from: startAngle / 360, to: endAngle / 360)
                 .fill(
                     LinearGradient(
-                        colors: [.black.opacity(0.1), .clear, .white.opacity(0.2)],
+                        colors: [.black.opacity(0.1), .clear, Color.yellow.opacity(0.2)],
                         startPoint: .topLeading,
                         endPoint: .bottomTrailing
                     )
@@ -369,7 +369,7 @@ struct ProfessionalWheelSegment: View {
                 .font(.system(size: 24, weight: .black, design: .rounded))
                 .foregroundStyle(
                     LinearGradient(
-                        colors: [.white, .white.opacity(0.8)],
+                        colors: [Color.yellow, Color.green.opacity(0.8)],
                         startPoint: .top,
                         endPoint: .bottom
                     )
@@ -434,7 +434,7 @@ struct ResultView: View {
                     VStack(spacing: 20) {
                         Text("Sonuç Açıklandı!")
                             .font(.system(size: 24, weight: .bold, design: .rounded))
-                            .foregroundColor(.white.opacity(0.9))
+                            .foregroundColor(.yellow.opacity(0.9))
                         
                         // Sonuç kartı
                         ZStack {
@@ -456,7 +456,7 @@ struct ResultView: View {
                                 .font(.system(size: 48, weight: .black, design: .rounded))
                                 .foregroundStyle(
                                     LinearGradient(
-                                        colors: [.white, .white.opacity(0.8)],
+                                        colors: [Color.yellow, Color.green.opacity(0.8)],
                                         startPoint: .top,
                                         endPoint: .bottom
                                     )
@@ -474,11 +474,11 @@ struct ResultView: View {
                             Text("Tamam")
                                 .font(.system(size: 18, weight: .bold, design: .rounded))
                         }
-                        .foregroundColor(.white)
+                        .foregroundColor(.yellow)
                         .frame(width: 150, height: 55)
                         .background(
                             LinearGradient(
-                                colors: [.blue, .purple],
+                                colors: [Color.green, Color.yellow],
                                 startPoint: .leading,
                                 endPoint: .trailing
                             )
@@ -486,9 +486,9 @@ struct ResultView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 27))
                         .overlay(
                             RoundedRectangle(cornerRadius: 27)
-                                .stroke(.white.opacity(0.3), lineWidth: 1)
+                                .stroke(Color.yellow.opacity(0.3), lineWidth: 1)
                         )
-                        .shadow(color: .blue.opacity(0.3), radius: 15, x: 0, y: 8)
+                        .shadow(color: Color.yellow.opacity(0.3), radius: 15, x: 0, y: 8)
                     }
                 }
                 .transition(.scale.combined(with: .opacity))

--- a/carkspin/UsernameSetupView.swift
+++ b/carkspin/UsernameSetupView.swift
@@ -8,9 +8,9 @@ struct UsernameSetupView: View {
     var body: some View {
         ZStack {
             LinearGradient(
-                gradient: Gradient(colors: [Color.blue.opacity(0.6), Color.purple.opacity(0.8)]),
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
+                gradient: Gradient(colors: [Color.black, Color.green.opacity(0.7)]),
+                startPoint: .top,
+                endPoint: .bottom
             )
             .ignoresSafeArea()
             
@@ -19,17 +19,16 @@ struct UsernameSetupView: View {
                 
                 VStack(spacing: 20) {
                     Image(systemName: "person.badge.plus")
-                        .font(.system(size: 80))
-                        .foregroundColor(.white)
-                    
+                        .font(.system(size: 80, weight: .black, design: .rounded))
+                        .foregroundStyle(.yellow)
+
                     Text("Kullanıcı Adın")
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
-                        .foregroundColor(.white)
-                    
+                        .font(.system(size: 34, weight: .heavy, design: .rounded))
+                        .foregroundColor(.yellow)
+
                     Text("Arkadaşlarının seni bulabilmesi için bir kullanıcı adı seç")
-                        .font(.body)
-                        .foregroundColor(.white.opacity(0.8))
+                        .font(.system(size: 16, weight: .medium, design: .rounded))
+                        .foregroundColor(.yellow.opacity(0.9))
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 40)
                 }
@@ -58,13 +57,16 @@ struct UsernameSetupView: View {
                         userService.setUsername(username)
                     }) {
                         Text("Devam Et")
-                            .fontWeight(.semibold)
+                            .font(.system(size: 16, weight: .bold, design: .rounded))
                             .frame(maxWidth: .infinity)
-                            .frame(height: 50)
-                            .background(isValidUsername ? Color.white : Color.gray.opacity(0.5))
-                            .foregroundColor(isValidUsername ? .primary : .white)
-                            .cornerRadius(25)
-                            .shadow(radius: isValidUsername ? 10 : 0, x: 0, y: isValidUsername ? 5 : 0)
+                            .frame(height: 55)
+                            .background(
+                                LinearGradient(colors: [Color.green, Color.yellow], startPoint: .topLeading, endPoint: .bottomTrailing)
+                                    .opacity(isValidUsername ? 1 : 0.5)
+                            )
+                            .foregroundColor(.yellow)
+                            .clipShape(Capsule())
+                            .shadow(color: .black.opacity(isValidUsername ? 0.2 : 0), radius: 5, x: 0, y: 3)
                     }
                     .disabled(!isValidUsername || userService.isLoading)
                     .opacity(!isValidUsername || userService.isLoading ? 0.6 : 1.0)
@@ -72,7 +74,7 @@ struct UsernameSetupView: View {
                     if userService.isLoading {
                         ProgressView()
                             .scaleEffect(1.2)
-                            .tint(.white)
+                            .tint(.yellow)
                     }
                     
                     if let errorMessage = userService.errorMessage {


### PR DESCRIPTION
## Summary
- switch app gradients to black backgrounds with green and yellow accents
- use yellow text styling across login, friends, username setup, and wheel views
- adapt wheel graphics and buttons to green–yellow gradients

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6867b051ea9c83258decb555cb75b66b